### PR TITLE
chore(ci): advance OpenSSF Scorecard P0 + P1

### DIFF
--- a/.claude/SCORECARD-PLAN.md
+++ b/.claude/SCORECARD-PLAN.md
@@ -17,8 +17,8 @@ API: https://api.securityscorecards.dev/projects/github.com/EventoFramework/even
 | License | 9 | Low | ⏸️ maintainer chose to leave (custom dual-license) |
 | Signed-Releases | 8 | High | ◑ improves to ~10 once a real `v*` tag runs `release.yml` (provenance) |
 | Binary-Artifacts | 8 | High | ⏸️ `gradle-wrapper.jar` unavoidable; `graphvizlib.wasm` optional |
-| Pinned-Dependencies | 8 | Medium | ▶ **P1** — one unpinned `pip install` left |
-| Branch-Protection | -1 | High | ▶ **P0** — enabled, but Scorecard needs a PAT to read it |
+| Pinned-Dependencies | 8 | Medium | ✅ **P1 done** — `pip install requests` removed (`publish.py` → stdlib `urllib`); expected → 10 next scan |
+| Branch-Protection | -1 | High | ◑ **P0 wired** — `scorecard.yml` now passes `repo_token: SCORECARD_TOKEN`; effective once the maintainer sets that secret |
 | CI-Tests | -1 | Low | ▶ **P2** — resolves once changes merge via PR |
 | Code-Review | 0 | High | ▶ **P2** — needs approved+merged PRs |
 | CII-Best-Practices | 0 | Low | ▶ **P3** — register the badge (manual) |
@@ -37,30 +37,29 @@ because it re-adds a **High**-weight check to the aggregate.
 but `scorecard.yml` runs with the default `GITHUB_TOKEN`, which cannot read
 branch-protection settings → `-1 internal error`. Documented fix: a PAT.
 
-**Steps (maintainer creates the token; I wire the workflow):**
+**Workflow wired (2026-05-31):** `scorecard.yml` now passes
+`repo_token: ${{ secrets.SCORECARD_TOKEN }}` to the action. **Maintainer TODO
+before the next scan:**
 1. Create a **classic PAT** with scopes `repo` + `read:org` (or a fine-grained
    token with **Administration: read** + **Contents: read** on this repo).
 2. `gh secret set SCORECARD_TOKEN --repo EventoFramework/evento-framework < token.txt`
-3. In `scorecard.yml`, pass it to the action:
-   ```yaml
-   - uses: ossf/scorecard-action@<pinned-sha>
-     with:
-       results_file: results.sarif
-       results_format: sarif
-       repo_token: ${{ secrets.SCORECARD_TOKEN }}
-       publish_results: true
-   ```
+
+⚠️ Set the secret **before merge / before the next Tuesday scan** — an empty
+`SCORECARD_TOKEN` would make the action run with a blank token and fail.
+
 **Expected:** Branch-Protection ~7–9 (our config: required PR+approval, required
 status checks, no force-push/delete; admins-bypass and no required signatures
 cap it below 10). Overall → low-to-mid 7s.
 
-## P1 — Pinned-Dependencies 8 → 10 (I can do now, zero risk)
-**Why:** Only remaining unpinned dependency is `pip install requests` in
+## P1 — Pinned-Dependencies 8 → 10 ✅ DONE (2026-05-31)
+**Why:** Only remaining unpinned dependency was `pip install requests` in
 `maven-build-and-push-repository.yaml`.
-**Fix:** Rewrite `publish.py` to use the stdlib (`urllib.request`) instead of
-`requests`, and delete the `Set up Python deps` / `pip install` step. Removes the
-dependency entirely — nothing left to pin.
-**Expected:** Pinned-Dependencies → 10.
+**Fix shipped:** Rewrote `publish.py` to use the stdlib (`urllib.request` +
+`base64` Basic auth) instead of `requests`; removed the `Set up Python` and
+`Install Python dependencies` (`pip install requests`) steps from the workflow;
+promote step now invokes `python3 publish.py` (no `setup-python`, runner's
+pre-installed interpreter). Nothing left to pin in that workflow.
+**Expected:** Pinned-Dependencies → 10 on the next scan.
 
 ## P2 — Code-Review + CI-Tests (behavioral)
 **Why:** 0 approved changesets / no PR found — everything lands via direct push

--- a/.github/workflows/maven-build-and-push-repository.yaml
+++ b/.github/workflows/maven-build-and-push-repository.yaml
@@ -24,14 +24,6 @@ jobs:
           java-version: '25'
           cache: gradle
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: '3.x'
-
-      - name: Install Python dependencies
-        run: pip install requests
-
       # Uploads signed artifacts to the Sonatype ossrh-staging-api staging
       # repository. Credentials and the in-memory GPG key are read from the
       # environment (see evento-*/build.gradle). Scoped to the Central
@@ -47,7 +39,7 @@ jobs:
       # Promotes the staged com.eventoframework namespace for release
       # (publishing_type=automatic), the same finalization done locally.
       - name: Promote staging to Central
-        run: python publish.py
+        run: python3 publish.py
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # PAT (repo + read:org) so Scorecard can read branch-protection
+          # settings — the default GITHUB_TOKEN cannot, which left
+          # Branch-Protection at -1 (internal error). See SCORECARD-PLAN.md P0.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: true
 
       - name: Upload SARIF

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,8 @@ __pycache__/
 
 # Node (root-level safety net; module-level node_modules are covered per-directory)
 node_modules/
+
+# Secret material — never commit (e.g. PATs staged for `gh secret set`)
+token.txt
+*.pat
+*.token

--- a/publish.py
+++ b/publish.py
@@ -1,7 +1,8 @@
+import base64
 import os
 import sys
-
-import requests
+import urllib.error
+import urllib.request
 
 NAMESPACE = "com.eventoframework"
 BASE = "https://ossrh-staging-api.central.sonatype.com"
@@ -46,23 +47,35 @@ def resolve_credentials():
     return username, password
 
 
+def request(method, url, auth):
+    """Issue an HTTP request with Basic auth, returning the response body text.
+
+    Raises on a non-2xx status (mirrors requests' raise_for_status()).
+    """
+    username, password = auth
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Authorization", f"Basic {token}")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        sys.exit(f"HTTP {e.code} for {method} {url}:\n{body}")
+
+
 if __name__ == "__main__":
     auth = resolve_credentials()
 
     print("Staging repositories before promotion:")
-    resp = requests.get(f"{BASE}/manual/search/repositories", auth=auth)
-    resp.raise_for_status()
-    print(resp.text)
+    print(request("GET", f"{BASE}/manual/search/repositories", auth))
 
     print(f"\nPromoting namespace {NAMESPACE} (publishing_type=automatic)...")
-    resp = requests.post(
+    print(request(
+        "POST",
         f"{BASE}/manual/upload/defaultRepository/{NAMESPACE}?publishing_type=automatic",
-        auth=auth,
-    )
-    resp.raise_for_status()
-    print(resp.text)
+        auth,
+    ))
 
     print("\nStaging repositories after promotion:")
-    resp = requests.get(f"{BASE}/manual/search/repositories", auth=auth)
-    resp.raise_for_status()
-    print(resp.text)
+    print(request("GET", f"{BASE}/manual/search/repositories", auth))


### PR DESCRIPTION
Advances two levers from `.claude/SCORECARD-PLAN.md`.

## P1 — Pinned-Dependencies (8 → 10)
The last unpinned dependency was `pip install requests` in `maven-build-and-push-repository.yaml`. `publish.py` is rewritten against the stdlib (`urllib.request` + `base64` Basic auth), so the third-party dependency disappears entirely — nothing left to pin. The `Set up Python` and `Install Python dependencies` steps are removed; the promote step now runs `python3 publish.py` against the runner's pre-installed interpreter.

## P0 — Branch-Protection (−1 → real score)
The default `GITHUB_TOKEN` can't read branch-protection settings, leaving this **High**-weight check at an internal-error `−1` (excluded from the average). The action now receives a PAT via `repo_token: ${{ secrets.SCORECARD_TOKEN }}` so Scorecard can read the live rules — the single biggest remaining lever.

> [!IMPORTANT]
> The `SCORECARD_TOKEN` secret (classic PAT: `repo` + `read:org`) **must be set before this merges / before the next Tuesday scan**, or the Scorecard action runs with a blank token and fails.

## Verification
- `publish.py` syntax + `py_compile` pass.
- No behavior change to the publish flow (same endpoints, same Basic auth, same env-var credential resolution).

Merging this via PR (not admin-bypass push) also feeds the **CI-Tests** / **Code-Review** Scorecard checks (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)