### PR TITLE
chore(deps): upgrade to Spring Boot 4.1.0

### DIFF
--- a/evento-lab-microservices/evento-lab-ms-api/build.gradle
+++ b/evento-lab-microservices/evento-lab-ms-api/build.gradle
@@ -7,7 +7,7 @@ group 'com.evento'
 version "${eventoVersion}"
 java { toolchain { languageVersion = javaLanguageVersion } }
 dependencyManagement {
-    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.5' }
+    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:4.1.0' }
 }
 repositories { mavenCentral(); mavenLocal() }
 dependencies {

--- a/evento-lab-microservices/evento-lab-ms-command/build.gradle
+++ b/evento-lab-microservices/evento-lab-ms-command/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }

--- a/evento-lab-microservices/evento-lab-ms-it/build.gradle
+++ b/evento-lab-microservices/evento-lab-ms-it/build.gradle
@@ -6,7 +6,7 @@ group 'com.evento'
 version "${eventoVersion}"
 java { toolchain { languageVersion = javaLanguageVersion } }
 dependencyManagement {
-    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.5' }
+    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:4.1.0' }
 }
 repositories { mavenCentral(); mavenLocal() }
 dependencies {

--- a/evento-lab-microservices/evento-lab-ms-observer/build.gradle
+++ b/evento-lab-microservices/evento-lab-ms-observer/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }

--- a/evento-lab-microservices/evento-lab-ms-query/build.gradle
+++ b/evento-lab-microservices/evento-lab-ms-query/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }

--- a/evento-lab-microservices/evento-lab-ms-saga/build.gradle
+++ b/evento-lab-microservices/evento-lab-ms-saga/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }

--- a/evento-lab/build.gradle
+++ b/evento-lab/build.gradle
@@ -10,11 +10,11 @@ java {
     toolchain { languageVersion = javaLanguageVersion }
 }
 
-// Pull in the Spring Boot 3.5.5 BOM so that transitive Spring deps from
+// Pull in the Spring Boot 4.1.0 BOM so that transitive Spring deps from
 // evento-server resolve to concrete versions without specifying each one.
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.5'
+        mavenBom 'org.springframework.boot:spring-boot-dependencies:4.1.0'
     }
     // Flyway 12.x ships Jackson 3 (tools.jackson.*), whose annotation introspector
     // references com.fasterxml.jackson.annotation.JsonSerializeAs (jackson-annotations

--- a/evento-server/build.gradle
+++ b/evento-server/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.5.5'
+	id 'org.springframework.boot' version '4.1.0'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
 }

--- a/evento-server/src/main/java/com/evento/server/bus/spring/BusHealthIndicator.java
+++ b/evento-server/src/main/java/com/evento/server/bus/spring/BusHealthIndicator.java
@@ -1,8 +1,8 @@
 package com.evento.server.bus.spring;
 
 import com.evento.server.bus.lifecycle.BusLifecycle;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
 
 /**
  * Actuator health contribution for the v2 bus. Reports {@code UP} once the Netty transport is

--- a/evento-server/src/test/java/com/evento/server/bus/lifecycle/BundleClientIT.java
+++ b/evento-server/src/test/java/com/evento/server/bus/lifecycle/BundleClientIT.java
@@ -291,7 +291,12 @@ class BundleClientIT {
     void encryptedRoundTripWithSelfSignedTls() throws Exception {
         SelfSignedCertificate ssc;
         try {
-            ssc = new SelfSignedCertificate();
+            // Issue the cert for the DNS name "localhost" (not the 127.0.0.1 IP literal):
+            // Netty 4.2 enables TLS hostname verification by default, and IP-literal
+            // verification requires an iPAddress SAN that SelfSignedCertificate does not
+            // mint. A DNS name verifies against the certificate CN, so client and server
+            // below connect via "localhost" to match.
+            ssc = new SelfSignedCertificate("localhost");
         } catch (Throwable t) {
             // Netty 4.1's SelfSignedCertificate falls back through sun.security helpers
             // that have been progressively restricted in newer JDKs. Skip the test on
@@ -329,12 +334,12 @@ class BundleClientIT {
         port = lifecycle.start(0);
 
         try (var handler = BundleClient.builder("h", "h1")
-                .host("127.0.0.1").port(port).bundleVersion("100")
+                .host("localhost").port(port).bundleVersion("100")
                 .authToken(GOOD_TOKEN)
                 .handlerPayloadTypes(List.of("com.tls"))
                 .transportConfig(tlsClientConfig).build();
              var caller = BundleClient.builder("c", "c1")
-                     .host("127.0.0.1").port(port).bundleVersion("100")
+                     .host("localhost").port(port).bundleVersion("100")
                      .authToken(GOOD_TOKEN)
                      .transportConfig(tlsClientConfig).build()) {
 

--- a/evento-transport-netty/src/main/java/com/evento/transport/netty/EventoPipelineFactory.java
+++ b/evento-transport-netty/src/main/java/com/evento/transport/netty/EventoPipelineFactory.java
@@ -22,9 +22,25 @@ import java.util.function.Consumer;
 final class EventoPipelineFactory {
 
     private final NettyTransportConfig config;
+    private final String peerHost;
+    private final int peerPort;
 
+    /** Server-side factory: TLS handlers are built without a peer identity. */
     EventoPipelineFactory(NettyTransportConfig config) {
+        this(config, null, -1);
+    }
+
+    /**
+     * Client-side factory. When {@code peerHost} is non-null the TLS handler is
+     * created with the remote host/port so that SNI is sent and the peer
+     * certificate is verified against that host. Netty 4.2 enables endpoint
+     * identification by default, so a handler built without a peer identity
+     * fails the handshake — the host/port must be threaded through here.
+     */
+    EventoPipelineFactory(NettyTransportConfig config, String peerHost, int peerPort) {
         this.config = config;
+        this.peerHost = peerHost;
+        this.peerPort = peerPort;
     }
 
     void configure(Channel ch,
@@ -34,7 +50,10 @@ final class EventoPipelineFactory {
         ChannelPipeline p = ch.pipeline();
         // TLS, if configured, must run before any framing/decoder so it operates on raw socket bytes.
         if (config.sslContext() != null) {
-            p.addLast("tls", config.sslContext().newHandler(ch.alloc()));
+            var ssl = peerHost != null
+                    ? config.sslContext().newHandler(ch.alloc(), peerHost, peerPort)
+                    : config.sslContext().newHandler(ch.alloc());
+            p.addLast("tls", ssl);
         }
         p.addLast("frameDec", new LengthFieldBasedFrameDecoder(
                 config.maxFrameLength(), 0, 4, 0, 4));

--- a/evento-transport-netty/src/main/java/com/evento/transport/netty/NettyClientTransport.java
+++ b/evento-transport-netty/src/main/java/com/evento/transport/netty/NettyClientTransport.java
@@ -61,7 +61,7 @@ public final class NettyClientTransport implements Transport {
         this.port = port;
         this.config = Objects.requireNonNull(config);
         this.state = new ConnectionStateMachine("client:" + remoteId);
-        this.pipelineFactory = new EventoPipelineFactory(config);
+        this.pipelineFactory = new EventoPipelineFactory(config, host, port);
         if (sharedWorkerGroup != null) {
             this.workerGroup = sharedWorkerGroup;
             this.ownsWorkerGroup = false;


### PR DESCRIPTION
Consolidates the two Dependabot PRs that can only land together — the Gradle plugin bump (**#137**) and the dependency BOM bump (**#134**) — plus the source changes the major requires.

### Version bumps (3.5.5 → 4.1.0)
`org.springframework.boot` plugin id (evento-server + evento-lab-microservices apps) and every `spring-boot-dependencies` BOM import (evento-server, evento-lab, evento-lab-ms-api, evento-lab-ms-it).

### Migration changes
- **Actuator**: health-contributor types moved packages in SB4 — `org.springframework.boot.actuate.health.{Health,HealthIndicator}` → `org.springframework.boot.health.contributor.*`. Imports updated in `BusHealthIndicator`; the `Health` builder API is unchanged.
- **⚠️ BREAKING (TLS)**: SB4's BOM upgrades **Netty 4.1 → 4.2**, which enables TLS hostname verification by default. The client pipeline built its `SslHandler` with no peer identity, so under 4.2 *every* TLS handshake fails. `NettyClientTransport` now threads the remote host/port into `EventoPipelineFactory`, which builds the client handler via `SslContext.newHandler(alloc, host, port)` — SNI is sent and the broker cert is verified against the connected host. Server handlers remain peer-less.
  - **Operator impact**: TLS deployments must now present a broker certificate whose CN/SAN matches the host bundles connect to. Certs that "worked" only because verification was off will be rejected. IP-literal hosts need an `iPAddress` SAN.
- **Test**: `encryptedRoundTripWithSelfSignedTls` now mints the self-signed cert for `localhost` and connects via `localhost`.

### Validation
Full CI test set (transport-api, transport-netty, server, common, bundle, lab, lab-ms-it) green locally on JDK 25.

Closes #137, closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)